### PR TITLE
Fix shim implementation of `hash_pbkdf2` to work properly when `length` is zero

### DIFF
--- a/src/Encryptor/OpenSsl.php
+++ b/src/Encryptor/OpenSsl.php
@@ -40,8 +40,11 @@ if (!function_exists('hash_pbkdf2')) {
      * binary representation of the derived key is returned.
      * @since 5.5.0
      */
-    function hash_pbkdf2($algo, $password, $salt, $iterations, $length, $raw_output) {
+    function hash_pbkdf2($algo, $password, $salt, $iterations, $length = 0, $raw_output = false) {
         $size   = strlen(hash($algo, '', true));
+        if ($length === 0) {
+            $length = $size;
+        }
         $len    = ceil($length / $size);
         $result = '';
         for ($i = 1; $i <= $len; $i++) {


### PR DESCRIPTION
According to the PHP docs, when length is set to `0` (as it should be by default when not specified), the length returned should be the size of the output from the specified hash algorithm.

This fixes the implementation to allow this, and makes the last two arguments optional as they are supposed to be.

Fixes #1
